### PR TITLE
Refactor `ErrorReporter` to use new loggers

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="ProjectKey">
     <option name="state" value="project://e2804f05-5315-4fc6-a121-c522a6c26470" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_13" default="true" project-jdk-name="13" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/dev/frendli/ConsoleLogger.java
+++ b/src/dev/frendli/ConsoleLogger.java
@@ -1,0 +1,19 @@
+package dev.frendli;
+
+/**
+ * The console logger - logs messages to the console.
+ */
+public class ConsoleLogger implements Logger {
+    @Override
+    public void log(String message) {
+        System.out.println(message);
+    }
+
+    public void logSameLine(String message) {
+        System.out.print(message);
+    }
+
+    public void logError(String message) {
+        System.err.println(message);
+    }
+}

--- a/src/dev/frendli/ErrorReporter.java
+++ b/src/dev/frendli/ErrorReporter.java
@@ -1,12 +1,16 @@
 package dev.frendli;
 
 /**
- * The error reporter - reports any errors found. All
- * error reporters must extend the ErrorReporter base class.
+ * The error reporter - reports any errors found.
  */
-public abstract class ErrorReporter {
+public class ErrorReporter {
+    private final Logger logger;
     private boolean compileTimeErrorReported = false;
     private boolean runtimeErrorReported = false;
+
+    public ErrorReporter(Logger logger) {
+        this.logger = logger;
+    }
 
     public boolean hadCompileTimeError() {
         return compileTimeErrorReported;
@@ -49,21 +53,15 @@ public abstract class ErrorReporter {
         runtimeErrorReported = false;
     }
 
-    protected abstract void report(int line, String location, String message);
+    private void report(int line, String location, String message) {
+        logger.log(format(line, location, message));
+    }
 
-    /**
-     * The console error reporter - reports errors to the console.
-     */
-    public static class Console extends ErrorReporter {
-        @Override
-        protected void report(int line, String location, String message) {
-            System.err.println(" Error\n" +
-                    "   > Where: \n" +
-                    "      > Line " + line + " " + location + "\n" +
-                    "   > Message: \n" +
-                    "      > " + message + "\n"
-            );
-            System.out.println();
-        }
+    private String format(int line, String location, String message) {
+        return "Error\n" +
+                "  > Where: \n" +
+                "     > Line " + line + " " + location + "\n" +
+                "  > Message: \n" +
+                "     > " + message + "\n\n";
     }
 }

--- a/src/dev/frendli/FileLogger.java
+++ b/src/dev/frendli/FileLogger.java
@@ -1,0 +1,42 @@
+package dev.frendli;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * The file logger - logs messages to a file.
+ * The content of the output file will be cleared on instantiation.
+ */
+public class FileLogger implements Logger {
+    private String outputPath = "frendli-default.log";
+
+    public FileLogger() {
+        clearFile();
+    }
+
+    public FileLogger(String outputPath) {
+        this.outputPath = outputPath;
+        clearFile();
+    }
+
+    @Override
+    public void log(String message) {
+        try (var fileWriter = new FileWriter(outputPath, true)) {
+            fileWriter.write(message + "\n");
+        }
+        catch (IOException error) {
+            System.err.println("There was an error writing to the log file:");
+            error.printStackTrace();
+        }
+    }
+
+    private void clearFile() {
+        try (var fileWriter = new FileWriter(outputPath)) {
+            fileWriter.write("");
+        }
+        catch (IOException error) {
+            System.err.println("There was an error clearing the log file:");
+            error.printStackTrace();
+        }
+    }
+}

--- a/src/dev/frendli/Interpreter.java
+++ b/src/dev/frendli/Interpreter.java
@@ -17,9 +17,9 @@ public class Interpreter implements ExpressionVisitor<Object>, StatementVisitor<
     private final Map<Token, Integer> resolved = new HashMap<>();       // Variables (key) resolved by the resolver (value = distance to corresponding environment)
     private final List<String> nativeNames = new ArrayList<>();         // The names of standard library members (used by Resolver)
 
-    public Interpreter(ErrorReporter reporter) {
+    public Interpreter(ErrorReporter reporter, Logger logger) {
         globalEnvironment.defineNative("time", new NativeFunction.Time());
-        globalEnvironment.defineNative("display", new NativeFunction.Display());
+        globalEnvironment.defineNative("display", new NativeFunction.Display(logger));
         nativeNames.add("time");
         nativeNames.add("display");
         this.reporter = reporter;

--- a/src/dev/frendli/Logger.java
+++ b/src/dev/frendli/Logger.java
@@ -1,0 +1,5 @@
+package dev.frendli;
+
+public interface Logger {
+    void log(String message);
+}

--- a/src/dev/frendli/NativeFunction.java
+++ b/src/dev/frendli/NativeFunction.java
@@ -32,6 +32,11 @@ public abstract class NativeFunction implements FrendliCallable {
      * Native function for outputting a string representation to the user.
      */
     public static class Display extends NativeFunction {
+        private final Logger logger;
+
+        public Display(Logger logger) {
+            this.logger = logger;
+        }
         @Override
         public int arity() {
             return 1;
@@ -71,7 +76,9 @@ public abstract class NativeFunction implements FrendliCallable {
         }
 
         private void print(String value) {
-            System.out.println(value);
+            // The default log mechanism is `System.out.println()`, but
+            // tests may modify this behavior to instead log to a file.
+            logger.log(value);
         }
     }
 }


### PR DESCRIPTION
Adds functionality to switch logger from the console (`System.out`) to writing to a file.

If using the `FileLogger`, errors and output are logged to a file. This is primarily to accommodate testing of Frendli.