### PR TITLE
Add tests for primary literal expression

### DIFF
--- a/src/test/java/tests/expressions/literals/LiteralsTest.java
+++ b/src/test/java/tests/expressions/literals/LiteralsTest.java
@@ -1,0 +1,60 @@
+package tests.expressions.literals;
+
+import tests.FrendliTestExpectSuccess;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LiteralsTest {
+    @Nested
+    public class LiteralsTestExpectSuccess extends FrendliTestExpectSuccess {
+        @Test
+        void itCanEvaluateNumber() {
+            String sourceFile = "expressions/literals/evaluate-number.frendli";
+            String actual = run(sourceFile);
+            String expected = """
+                    0
+                    1
+                    12.34
+                    1234567.89
+                    -1234567.89
+                    """.trim();
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void itCanEvaluateBoolean() {
+            String sourceFile = "expressions/literals/evaluate-boolean.frendli";
+            String actual = run(sourceFile);
+            String expected = """
+                    true
+                    false
+                    """.trim();
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void itCanEvaluateText() {
+            String sourceFile = "expressions/literals/evaluate-text.frendli";
+            String actual = run(sourceFile);
+            String expected = """
+                    abcdefghijklmnopqrstuvwxyz
+                    ABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+                    0123456789
+                    _ !#%&/=?*^-.:;<>()[]{}|'~
+                    """.trim();
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void itCanEvaluateEmpty() {
+            String sourceFile = "expressions/literals/evaluate-empty.frendli";
+            String actual = run(sourceFile);
+            String expected = "empty";
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/src/test/java/tests/expressions/literals/evaluate-boolean.frendli
+++ b/src/test/java/tests/expressions/literals/evaluate-boolean.frendli
@@ -1,0 +1,5 @@
+// Expect: true
+display(send true)
+
+// Expect: false
+display(send false)

--- a/src/test/java/tests/expressions/literals/evaluate-empty.frendli
+++ b/src/test/java/tests/expressions/literals/evaluate-empty.frendli
@@ -1,0 +1,2 @@
+// Expect: empty
+display(send empty)

--- a/src/test/java/tests/expressions/literals/evaluate-number.frendli
+++ b/src/test/java/tests/expressions/literals/evaluate-number.frendli
@@ -1,0 +1,14 @@
+// Expect: 0
+display(send 0)
+
+// Expect: 1
+display(send 1)
+
+// Expect: 12.34
+display(send 12.34)
+
+// Expect: 1234567.89
+display(send 1234567.890)
+
+// Expect: -1234567.89
+display(send -1234567.890)

--- a/src/test/java/tests/expressions/literals/evaluate-text.frendli
+++ b/src/test/java/tests/expressions/literals/evaluate-text.frendli
@@ -1,0 +1,14 @@
+// Expect: abcdefghijklmnopqrstuvwxyz
+display(send "abcdefghijklmnopqrstuvwxyz")
+
+// Expect: ABCDEFGHIJKLMNOPQRSTUVWXYZ
+display(send "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// Expect: <empty string>
+display(send "")
+
+// Expect: 0123456789
+display(send "0123456789")
+
+// Expect: _ !#%&/=?*^-.:;<>()[]{}|'~
+display(send "_ !#%&/=?*^-.:;<>()[]{}|'~")


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Adds tests for primary literal (`number`, `text`, `boolean`, `empty`) expression.
