### PR TITLE
Use default activity types for a PR event in GH workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,12 +4,13 @@ name: Run Tests
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'src/**'
       - 'pom.xml'
       - '.github/workflows/run-tests.yml'
   pull_request:
-    types: [ opened, edited ]
     paths:
       - 'src/**'
       - 'pom.xml'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,12 @@ on:
     paths:
       - 'src/**'
       - 'pom.xml'
-      - '.github/workflows/run-tests.yml'
+      - '.github/workflows/**'
   pull_request:
     paths:
       - 'src/**'
       - 'pom.xml'
-      - '.github/workflows/run-tests.yml'
+      - '.github/workflows/**'
 
 jobs:
   build:


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Updates when the `Run Tests` workflow should be triggered for `pull_request` events, now using the default activity types `opened`, `synchronize`, or `reopened`.
