### PR TITLE
Add tests for `//` (single-line comments)

### DIFF
--- a/src/test/java/tests/comments/CommentTest.java
+++ b/src/test/java/tests/comments/CommentTest.java
@@ -1,0 +1,77 @@
+package tests.comments;
+
+import tests.FrendliTestExpectSuccess;
+import tests.FrendliTestExpectError;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CommentTest {
+    @Nested
+    public class CommentTestExpectSuccess extends FrendliTestExpectSuccess {
+        @Test
+        void itIgnoresCommentSideEffects() {
+            String sourceFile = "comments/ignore-comment-side-effect.frendli";
+            String actual = run(sourceFile);
+            String expected = "10";
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void itIgnoresEmptyComment() {
+            String sourceFile = "comments/ignore-empty-comment.frendli";
+            String actual = run(sourceFile);
+            String expected = "";
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void itIgnoresSameLineComment() {
+            String sourceFile = "comments/ignore-same-line-comment.frendli";
+            String actual = run(sourceFile);
+            String expected = "";
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void itIgnoresCommentAtEndOfFile() {
+            String sourceFile = "comments/ignore-comment-at-eof.frendli";
+            String actual = run(sourceFile);
+            String expected = "";
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Nested
+    public class CommentTestExpectError extends FrendliTestExpectError {
+        @Test
+        void itCannotUseCommentAsVariable() {
+            String sourceFile = "comments/error-use-comment-as-variable.frendli";
+            String actual = runExpectComptimeError(sourceFile);
+            String expected = """
+                    Error
+                      > Where:
+                         > Line 4 at 'a'
+                      > Message:
+                         > 'a' has not been created or defined. To create it, use 'create', or define it using 'define'.
+                    """;
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void itCannotUseCommentAsValue() {
+            String sourceFile = "comments/error-use-comment-as-value.frendli";
+            String actual = runExpectComptimeError(sourceFile);
+            String expected = """
+                    Error
+                      > Where:
+                         > Line 2 at the end of the line
+                      > Message:
+                         > Cannot find a valid expression.
+                    """;
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/src/test/java/tests/comments/error-use-comment-as-value.frendli
+++ b/src/test/java/tests/comments/error-use-comment-as-value.frendli
@@ -1,0 +1,3 @@
+// Expect comptime error: Cannot find a valid expression.
+create a = // 1
+1

--- a/src/test/java/tests/comments/error-use-comment-as-variable.frendli
+++ b/src/test/java/tests/comments/error-use-comment-as-variable.frendli
@@ -1,0 +1,4 @@
+//create a = 10
+
+// Expect comptime error: 'a' has not been created or defined. To create it, use 'create', or define it using 'define'.
+change a = 9

--- a/src/test/java/tests/comments/ignore-comment-at-eof.frendli
+++ b/src/test/java/tests/comments/ignore-comment-at-eof.frendli
@@ -1,0 +1,2 @@
+// Expect: <no output>
+//this last line is a comment

--- a/src/test/java/tests/comments/ignore-comment-side-effect.frendli
+++ b/src/test/java/tests/comments/ignore-comment-side-effect.frendli
@@ -1,0 +1,9 @@
+create a = 10
+//change a = 9
+
+// Expect: 10
+display(send a)
+
+// Expect: <no output>
+//if true
+//  display(send true)

--- a/src/test/java/tests/comments/ignore-empty-comment.frendli
+++ b/src/test/java/tests/comments/ignore-empty-comment.frendli
@@ -1,0 +1,2 @@
+// Expect: <no output>
+//

--- a/src/test/java/tests/comments/ignore-same-line-comment.frendli
+++ b/src/test/java/tests/comments/ignore-same-line-comment.frendli
@@ -1,0 +1,4 @@
+// Expect: <no output>
+create a = 1 //display(send a)
+create b = 2 ///display(send b)
+create c = 3 ////display(send c)


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Adds tests for single-line comments starting with `//`.
